### PR TITLE
merge from svelte-guard-history-router

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,15 @@ updates:
     commit-message:
       prefix: 'fix(deps):'
       prefix-development: 'chore(deps):'
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: 'fix(deps):'
+      prefix-development: 'chore(deps):'
+    labels:
+      - npm dependencies
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -4,7 +4,7 @@ jobs:
   auto-approve:
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/auto-approve-action@v2
+      - uses: hmarr/auto-approve-action@v2.2.1
         if: github.actor == 'dependabot[bot]'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/browser_ci.yml
+++ b/.github/workflows/browser_ci.yml
@@ -9,12 +9,13 @@ jobs:
           - ubuntu-latest
         node:
           - 16.12.0
+          - 18.4.0
         browser:
           - chrome
           - firefox
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3.3.0
         with:
           node-version: ${{ matrix.node }}
           cache: npm
@@ -27,21 +28,24 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: build/coverage/lcov.info
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ${{ github.workspace }}/build/test/**/*
           retention-days: 3
           name: screenshots
         if: always()
+      - run: npm cit
+        env:
+          BROWSER: ${{ matrix.browser }}
   release:
     needs:
       - test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3.3.0
         with:
-          node-version: 16.12.0
+          node-version: 18.4.0
           cache: npm
       - run: npm install
       - run: npx semantic-release
@@ -49,3 +53,15 @@ jobs:
           CI: 'true'
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PKGBUILD_PUBLISH: ${{ secrets.PKGBUILD_PUBLISH }}
+      - name: Dependencies
+        run: >
+          sudo apt-get update
+
+          sudo apt-get install ksh curl
+
+          wget
+          https://github.com/ThePoorPilot/pacman-utils/releases/download/5.2.2-3_2.31-0/pacman-utils_5.2.2-3_amd64.deb
+
+          sudo apt-get install -f ./pacman-utils_5.2.2-3_amd64.deb
+      - run: npm ci

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -12,17 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - run: git checkout
         if: ${{ github.event_name == 'pull_request' }}
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: javascript
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3.3.0
         with:
-          node-version: 16.12.0
+          node-version: 18.4.0
           cache: npm
       - run: npm install
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2
+      - run: npm ci

--- a/.github/workflows/update_readme_api.yml
+++ b/.github/workflows/update_readme_api.yml
@@ -6,11 +6,12 @@ jobs:
   update_readme_api:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3.3.0
         with:
-          node-version: 16.12.0
+          node-version: 18.4.0
       - run: npm install
+      - run: npm ci
       - run: npm run docs
       - uses: gr2m/create-or-update-pull-request-action@v1
         env:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "router",
     "spa",
     "svelte",
+    "vite",
     "web"
   ],
   "contributors": [
@@ -21,15 +22,17 @@
   ],
   "license": "BSD-2-Clause",
   "scripts": {
-    "start": "rollup -c tests/app/rollup.config.mjs -w",
+    "prepare": "vite build",
+    "start": "rollup -c tests/app/rollup.config.mjs -w && vite dev",
     "test": "npm run test:ava && npm run test:cafe",
     "test:ava": "ava --timeout 2m tests/*.mjs",
-    "test:cafe": "testcafe $BROWSER:headless tests/cafe/*.js -s build/test --page-request-timeout 9000 --app-init-delay 3000 --app \"rollup -c tests/app/rollup.config.mjs -w\"",
+    "test:cafe": "testcafe $BROWSER:headless tests/cafe/*.js -s build/test --page-request-timeout 9000 --app-init-delay 3000 --app \"vite\"",
     "cover": "c8 -x 'tests/**/*' --temp-directory build/tmp ava --timeout 2m tests/*.mjs && c8 report -r lcov -o build/coverage --temp-directory build/tmp",
     "docs": "documentation readme --section=API ./src/**/*.mjs",
     "lint": "npm run lint:docs",
     "lint:docs": "documentation lint ./src/**/*.mjs",
-    "build": "rollup -c tests/app/rollup.config.mjs"
+    "build": "rollup -c tests/app/rollup.config.mjs && rollup -c {{rollup.config}}",
+    "preview": "vite preview"
   },
   "dependencies": {
     "multi-path-matcher": "^2.1.9"
@@ -37,20 +40,18 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@rollup/plugin-virtual": "^2.1.0",
-    "ava": "^4.1.0",
-    "c8": "^7.11.0",
+    "@sveltejs/vite-plugin-svelte": "^1.0.0-next.49",
+    "ava": "^4.3.0",
+    "c8": "^7.11.3",
     "documentation": "^13.2.5",
     "jsdom": "^20.0.0",
     "mf-styling": "arlac77/mf-styling",
-    "postcss": "^8.4.8",
-    "postcss-import": "^14.0.2",
     "rollup": "^2.75.7",
     "rollup-plugin-dev": "^2.0.3",
-    "rollup-plugin-postcss": "^4.0.2",
-    "rollup-plugin-svelte": "^7.1.0",
-    "semantic-release": "^19.0.2",
-    "svelte": "^3.46.4",
-    "testcafe": "^1.18.4"
+    "semantic-release": "^19.0.3",
+    "svelte": "^3.48.0",
+    "testcafe": "^1.19.0",
+    "vite": "^2.9.12"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
package.json
---
- chore(package): add vite (keywords)
chore(scripts): add rollup -c tests/app/rollup.config.mjs -w && vite dev (scripts.start)
chore(scripts): add testcafe $BROWSER:headless tests/cafe/*.js -s build/test --page-request-timeout 9000 --app-init-delay 3000 --app "vite" (scripts.test:cafe)
chore(scripts): add rollup -c tests/app/rollup.config.mjs && rollup -c {{rollup.config}} (scripts.build)
chore(scripts): add vite build (scripts.prepare)
chore(scripts): add vite preview (scripts.preview)
chore(deps): add ^4.3.0 remove ^4.1.0 (devDependencies.ava)
chore(deps): add ^7.11.3 remove ^7.11.0 (devDependencies.c8)
chore(deps): remove ^8.4.8 (devDependencies.postcss)
chore(deps): remove ^14.0.2 (devDependencies.postcss-import)
chore(deps): remove ^4.0.2 (devDependencies.rollup-plugin-postcss)
chore(deps): remove ^7.1.0 (devDependencies.rollup-plugin-svelte)
chore(deps): add ^19.0.3 remove ^19.0.2 (devDependencies.semantic-release)
chore(deps): add ^3.48.0 remove ^3.46.4 (devDependencies.svelte)
chore(deps): add ^1.19.0 remove ^1.18.4 (devDependencies.testcafe)
chore(deps): add ^1.0.0-next.49 (devDependencies.@sveltejs/vite-plugin-svelte)
chore(deps): add ^2.9.12 (devDependencies.vite)

.github/dependabot.yml
---
- chore: (updates)

.github/workflows/auto_approve.yml
---
- chore: add hmarr/auto-approve-action@v2.2.1 (jobs.auto-approve.steps.uses)

.github/workflows/codeql_analysis.yml
---
- chore: add actions/checkout@v3 (jobs.analyze.steps.uses)
chore: add github/codeql-action/init@v2 (jobs.analyze.steps.uses)
chore: add actions/setup-node@v3.3.0 (jobs.analyze.steps.uses)
chore: add 18.4.0 (jobs.analyze.steps.with.node-version)
chore: (jobs.analyze.steps)
chore: add github/codeql-action/analyze@v2 (jobs.analyze.steps.uses)

.github/workflows/browser_ci.yml
---
- chore(deps): add 18.4.0 (jobs.test.strategy.matrix.node)
chore: add actions/checkout@v3 (jobs.test.steps.uses)
chore: add actions/setup-node@v3.3.0 (jobs.test.steps.uses)
chore: (jobs.test.steps)
chore: add actions/upload-artifact@v3 (jobs.test.steps.uses)
chore: (jobs.release.steps)
chore: add actions/checkout@v3 (jobs.release.steps.uses)
chore: add actions/setup-node@v3.3.0 (jobs.release.steps.uses)
chore: add 18.4.0 (jobs.release.steps.with.node-version)
chore: (jobs.release.steps)
chore: add ${{ secrets.PKGBUILD_PUBLISH }} (jobs.release.steps.env.PKGBUILD_PUBLISH)

.github/workflows/update_readme_api.yml
---
- chore: add actions/checkout@v3 (jobs.update_readme_api.steps.uses)
chore: add actions/setup-node@v3.3.0 (jobs.update_readme_api.steps.uses)
chore: add 18.4.0 (jobs.update_readme_api.steps.with.node-version)
chore: (jobs.update_readme_api.steps)

