### PR TITLE
merge from svelte-guard-history-router

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "router",
     "spa",
     "svelte",
+    "vite",
     "web"
   ],
   "contributors": [
@@ -21,15 +22,17 @@
   ],
   "license": "BSD-2-Clause",
   "scripts": {
-    "start": "rollup -c tests/app/rollup.config.mjs -w",
+    "prepare": "vite build",
+    "start": "rollup -c tests/app/rollup.config.mjs -w && vite dev",
     "test": "npm run test:ava && npm run test:cafe",
     "test:ava": "ava --timeout 2m tests/*.mjs",
-    "test:cafe": "testcafe $BROWSER:headless tests/cafe/*.js -s build/test --page-request-timeout 9000 --app-init-delay 3000 --app \"rollup -c tests/app/rollup.config.mjs -w\"",
+    "test:cafe": "testcafe $BROWSER:headless tests/cafe/*.js -s build/test --page-request-timeout 9000 --app-init-delay 3000 --app \"vite\"",
     "cover": "c8 -x 'tests/**/*' --temp-directory build/tmp ava --timeout 2m tests/*.mjs && c8 report -r lcov -o build/coverage --temp-directory build/tmp",
     "docs": "documentation readme --section=API ./src/**/*.mjs",
     "lint": "npm run lint:docs",
     "lint:docs": "documentation lint ./src/**/*.mjs",
-    "build": "rollup -c tests/app/rollup.config.mjs"
+    "build": "rollup -c tests/app/rollup.config.mjs",
+    "preview": "vite preview"
   },
   "dependencies": {
     "multi-path-matcher": "^2.1.13"
@@ -37,20 +40,18 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-virtual": "^2.1.0",
+    "@sveltejs/vite-plugin-svelte": "^1.0.0-next.49",
     "ava": "^4.3.0",
     "c8": "^7.11.3",
     "documentation": "^13.2.5",
     "jsdom": "^20.0.0",
     "mf-styling": "^1.2.22",
-    "postcss": "^8.4.14",
-    "postcss-import": "^14.1.0",
     "rollup": "^2.75.7",
     "rollup-plugin-dev": "^2.0.1",
-    "rollup-plugin-postcss": "^4.0.2",
-    "rollup-plugin-svelte": "^7.1.0",
     "semantic-release": "^19.0.3",
     "svelte": "^3.48.0",
-    "testcafe": "^1.19.0"
+    "testcafe": "^1.19.0",
+    "vite": "^2.9.12"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
package.json
---
- chore(package): add vite (keywords)
chore(scripts): add rollup -c tests/app/rollup.config.mjs -w && vite dev (scripts.start)
chore(scripts): add testcafe $BROWSER:headless tests/cafe/*.js -s build/test --page-request-timeout 9000 --app-init-delay 3000 --app "vite" (scripts.test:cafe)
chore(scripts): add vite build (scripts.prepare)
chore(scripts): add vite preview (scripts.preview)
chore(deps): remove ^8.4.14 (devDependencies.postcss)
chore(deps): remove ^14.1.0 (devDependencies.postcss-import)
chore(deps): remove ^4.0.2 (devDependencies.rollup-plugin-postcss)
chore(deps): remove ^7.1.0 (devDependencies.rollup-plugin-svelte)
chore(deps): add ^1.0.0-next.49 (devDependencies.@sveltejs/vite-plugin-svelte)
chore(deps): add ^2.9.12 (devDependencies.vite)

